### PR TITLE
📦 add scipy for warp-by-vector-eigenmodes.ipynb

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,6 @@ dependencies:
   - lxml
   - pip:
     - git+git://github.com/pyvista/pyvista@master
+    - scipy
     - matplotlib
     - pyct


### PR DESCRIPTION
# Description

We need scipy install for ``warp-by-vector-eigenmodes.ipynb`` .

# Before

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyvista/pyvista-examples/master?filepath=examples%2F03-advanced%2Fwarp-by-vector-eigenmodes.ipynb) :point_left: Launch a binder notebook on master

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-bcf6a11e5a4d> in <module>
      1 import numpy as np
----> 2 from scipy.linalg import eigh
      3 import pyvista as pv
      4 
      5 

ModuleNotFoundError: No module named 'scipy'
```

# After

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tkoyama010/pyvista-examples/patch-2?filepath=examples%2F03-advanced%2Fwarp-by-vector-eigenmodes.ipynb) :point_left: Launch a binder notebook on this branch
![img](https://user-images.githubusercontent.com/7513610/88893433-49dc2600-d281-11ea-9e48-98903aaff64c.png)
